### PR TITLE
Add exclude private URLs feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
+dependencies = [
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +591,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +698,15 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1317,6 +1351,7 @@ name = "lychee"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "check-if-email-exists",
  "futures",
  "glob",
@@ -1326,6 +1361,7 @@ dependencies = [
  "indicatif",
  "linkify",
  "log",
+ "predicates",
  "pretty_env_logger",
  "regex",
  "reqwest",
@@ -1524,6 +1560,12 @@ dependencies = [
  "memchr",
  "version_check",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nuclei"
@@ -1752,6 +1794,35 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "predicates"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -2375,6 +2446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "trust-dns-proto"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2584,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ version = "0.2"
 
 [dev-dependencies]
 wiremock = "0.2.4"
+assert_cmd = "1.0"
+predicates = "1.0"

--- a/fixtures/TEST_ALL_PRIVATE.md
+++ b/fixtures/TEST_ALL_PRIVATE.md
@@ -1,0 +1,12 @@
+Test file: "private" URLs (should all be excluded when using `-E` flag).
+
+- Loopback: http://127.0.0.1
+- Link-local 1: http://169.254.0.1
+- Link-local 2: https://169.254.10.1:8080
+- Private class A: http://10.0.1.1
+- Private class B: http://172.16.42.42
+- Private class C: http://192.168.10.1
+
+IPv6:
+
+- Loopback: http://[::1]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -394,9 +394,7 @@ mod test {
     #[tokio::test]
     async fn test_nonexistent() {
         let res = get_checker(false, HeaderMap::new())
-            .check(&Uri::Website(
-                Url::parse("https://endler.dev/abcd").unwrap(),
-            ))
+            .check(&website_url("https://endler.dev/abcd"))
             .await;
         assert!(matches!(res, Status::Failed(_)));
     }
@@ -414,9 +412,7 @@ mod test {
     async fn test_github() {
         assert!(matches!(
             get_checker(false, HeaderMap::new())
-                .check(&Uri::Website(
-                    Url::parse("https://github.com/mre/idiomatic-rust").unwrap()
-                ))
+                .check(&website_url("https://github.com/mre/idiomatic-rust"))
                 .await,
             Status::Ok(_)
         ));
@@ -425,8 +421,8 @@ mod test {
     #[tokio::test]
     async fn test_github_nonexistent() {
         let res = get_checker(false, HeaderMap::new())
-            .check(&Uri::Website(
-                Url::parse("https://github.com/mre/idiomatic-rust-doesnt-exist-man").unwrap(),
+            .check(&website_url(
+                "https://github.com/mre/idiomatic-rust-doesnt-exist-man",
             ))
             .await;
         assert!(matches!(res, Status::Error(_)));
@@ -435,7 +431,7 @@ mod test {
     #[tokio::test]
     async fn test_non_github() {
         let res = get_checker(false, HeaderMap::new())
-            .check(&Uri::Website(Url::parse("https://endler.dev").unwrap()))
+            .check(&website_url("https://endler.dev"))
             .await;
         assert!(matches!(res, Status::Ok(_)));
     }
@@ -443,17 +439,13 @@ mod test {
     #[tokio::test]
     async fn test_invalid_ssl() {
         let res = get_checker(false, HeaderMap::new())
-            .check(&Uri::Website(
-                Url::parse("https://expired.badssl.com/").unwrap(),
-            ))
+            .check(&website_url("https://expired.badssl.com/"))
             .await;
         assert!(matches!(res, Status::Error(_)));
 
         // Same, but ignore certificate error
         let res = get_checker(true, HeaderMap::new())
-            .check(&Uri::Website(
-                Url::parse("https://expired.badssl.com/").unwrap(),
-            ))
+            .check(&website_url("https://expired.badssl.com/"))
             .await;
         assert!(matches!(res, Status::Ok(_)));
     }
@@ -461,9 +453,7 @@ mod test {
     #[tokio::test]
     async fn test_custom_headers() {
         let res = get_checker(false, HeaderMap::new())
-            .check(&Uri::Website(
-                Url::parse("https://crates.io/keywords/cassandra").unwrap(),
-            ))
+            .check(&website_url("https://crates.io/keywords/cassandra"))
             .await;
         assert!(matches!(res, Status::Failed(StatusCode::NOT_FOUND)));
 
@@ -473,9 +463,7 @@ mod test {
         let mut custom = HeaderMap::new();
         custom.insert(header::ACCEPT, "text/html".parse().unwrap());
         let res = get_checker(true, custom)
-            .check(&Uri::Website(
-                Url::parse("https://crates.io/keywords/cassandra").unwrap(),
-            ))
+            .check(&website_url("https://crates.io/keywords/cassandra"))
             .await;
         assert!(matches!(res, Status::Ok(_)));
     }
@@ -493,7 +481,7 @@ mod test {
             .await;
 
         let res = get_checker(false, HeaderMap::new())
-            .check(&Uri::Website(Url::parse(&mock_server.uri()).unwrap()))
+            .check(&website_url(&mock_server.uri()))
             .await;
         println!("{:?}", res);
         assert!(matches!(res, Status::Timeout));
@@ -520,14 +508,8 @@ mod test {
             None,
         )
         .unwrap();
-        assert_eq!(
-            checker.excluded(&Uri::Website(Url::parse("http://github.com").unwrap())),
-            true
-        );
-        assert_eq!(
-            checker.excluded(&Uri::Website(Url::parse("http://exclude.org").unwrap())),
-            true
-        );
+        assert_eq!(checker.excluded(&website_url("http://github.com")), true);
+        assert_eq!(checker.excluded(&website_url("http://exclude.org")), true);
         assert_eq!(
             checker.excluded(&Uri::Mail("mail@example.com".to_string())),
             true

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -80,11 +80,15 @@ pub(crate) struct Excludes {
 
 impl Excludes {
     pub fn from_options(options: &LycheeOptions) -> Self {
+        // exclude_all_private option turns on all "private" excludes,
+        // including private IPs, link-local IPs and loopback IPs
+        let enable_exclude = |opt| opt || options.exclude_all_private;
+
         Self {
             regex: RegexSet::new(&options.exclude).ok(),
-            private_ips: options.exclude_private,
-            link_local_ips: options.exclude_link_local,
-            loopback_ips: options.exclude_loopback,
+            private_ips: enable_exclude(options.exclude_private),
+            link_local_ips: enable_exclude(options.exclude_link_local),
+            loopback_ips: enable_exclude(options.exclude_loopback),
         }
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,5 +1,6 @@
 use linkify::LinkFinder;
 
+use std::net::IpAddr;
 use std::{collections::HashSet, fmt::Display};
 use url::Url;
 
@@ -21,6 +22,17 @@ impl Uri {
         match self {
             Uri::Website(url) => Some(url.scheme().to_string()),
             Uri::Mail(_address) => None,
+        }
+    }
+
+    pub fn host_ip(&self) -> Option<IpAddr> {
+        match self {
+            Self::Website(url) => match url.host()? {
+                url::Host::Ipv4(v4_addr) => Some(v4_addr.into()),
+                url::Host::Ipv6(v6_addr) => Some(v6_addr.into()),
+                _ => None,
+            },
+            Self::Mail(_) => None,
         }
     }
 }
@@ -56,6 +68,7 @@ pub(crate) fn extract_links(input: &str) -> HashSet<Uri> {
 mod test {
     use super::*;
     use std::iter::FromIterator;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn test_extract_markdown_links() {
@@ -112,5 +125,31 @@ mod test {
         let expected = "http://msdn.microsoft.com/library/ie/ms535874(v=vs.85).aspx)";
         assert!(links.len() == 1);
         assert_eq!(links[0].as_str(), expected);
+    }
+
+    #[test]
+    fn test_uri_host_ip_v4() {
+        let uri =
+            Uri::Website(Url::parse("http://127.0.0.1").expect("Expected URI with valid IPv4"));
+        let ip = uri.host_ip().expect("Expected a valid IPv4");
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    }
+
+    #[test]
+    fn test_uri_host_ip_v6() {
+        let uri =
+            Uri::Website(Url::parse("https://[2020::0010]").expect("Expected URI with valid IPv6"));
+        let ip = uri.host_ip().expect("Expected a valid IPv6");
+        assert_eq!(
+            ip,
+            IpAddr::V6(Ipv6Addr::new(0x2020, 0, 0, 0, 0, 0, 0, 0x10))
+        );
+    }
+
+    #[test]
+    fn test_uri_host_ip_no_ip() {
+        let uri = Uri::Website(Url::parse("https://some.cryptic/url").expect("Expected valid URI"));
+        let ip = uri.host_ip();
+        assert!(ip.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn print_summary(found: &HashSet<Uri>, results: &Vec<Status>) {
         .count();
     let errors: usize = found - excluded - success;
 
-    println!("");
+    println!();
     println!("📝Summary");
     println!("-------------------");
     println!("🔍Found: {}", found);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use futures::future::join_all;
 use gumdrop::Options;
 use indicatif::{ProgressBar, ProgressStyle};
-use regex::RegexSet;
 use reqwest::header::{HeaderMap, HeaderName};
 use std::{collections::HashSet, convert::TryInto, env, time::Duration};
 
@@ -15,7 +14,7 @@ mod collector;
 mod extract;
 mod options;
 
-use checker::{Checker, Status};
+use checker::{Checker, Excludes, Status};
 use extract::Uri;
 use options::LycheeOptions;
 
@@ -60,7 +59,7 @@ fn main() -> Result<()> {
 }
 
 async fn run(opts: LycheeOptions) -> Result<i32> {
-    let excludes = RegexSet::new(opts.exclude).unwrap();
+    let excludes = Excludes::from_options(&opts);
     let headers = parse_headers(opts.headers)?;
     let accepted = match opts.accept {
         Some(accept) => parse_statuscodes(accept)?,
@@ -82,7 +81,7 @@ async fn run(opts: LycheeOptions) -> Result<i32> {
     };
     let checker = Checker::try_new(
         env::var("GITHUB_TOKEN")?,
-        Some(excludes),
+        excludes,
         opts.max_redirects,
         opts.user_agent,
         opts.insecure,

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,13 +38,19 @@ pub(crate) struct LycheeOptions {
     #[options(help = "Exclude URLs from checking (supports regex)")]
     pub exclude: Vec<String>,
 
-    #[options(help = "Exclude private IP address ranges from checking")]
+    #[options(
+        help = "Exclude all private IPs from checking, equivalent to `--exclude-private --exclude-link-local --exclude--loopback`",
+        short = "E"
+    )]
+    pub exclude_all_private: bool,
+
+    #[options(help = "Exclude private IP address ranges from checking", no_short)]
     pub exclude_private: bool,
 
-    #[options(help = "Exclude link-local IP address range from checking")]
+    #[options(help = "Exclude link-local IP address range from checking", no_short)]
     pub exclude_link_local: bool,
 
-    #[options(help = "Exclude loopback IP address range from checking")]
+    #[options(help = "Exclude loopback IP address range from checking", no_short)]
     pub exclude_loopback: bool,
 
     // Accumulate all headers in a vector

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,6 +38,15 @@ pub(crate) struct LycheeOptions {
     #[options(help = "Exclude URLs from checking (supports regex)")]
     pub exclude: Vec<String>,
 
+    #[options(help = "Exclude private IP address ranges from checking")]
+    pub exclude_private: bool,
+
+    #[options(help = "Exclude link-local IP address range from checking")]
+    pub exclude_link_local: bool,
+
+    #[options(help = "Exclude loopback IP address range from checking")]
+    pub exclude_loopback: bool,
+
     // Accumulate all headers in a vector
     #[options(help = "Custom request headers")]
     pub headers: Vec<String>,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+mod cli {
+    use assert_cmd::Command;
+    use predicates::str::contains;
+    use std::path::Path;
+
+    #[test]
+    fn test_exclude_all_private() {
+        let mut cmd =
+            Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name");
+
+        let test_all_private_path = Path::new(module_path!())
+            .parent()
+            .unwrap()
+            .join("fixtures")
+            .join("TEST_ALL_PRIVATE.md");
+
+        // assert that the command runs OK, and that it excluded all the links
+        cmd.env("GITHUB_TOKEN", "invalid-token")
+            .arg("--exclude-all-private")
+            .arg("--verbose")
+            .arg(test_all_private_path)
+            .assert()
+            .success()
+            .stdout(contains("Found: 7"))
+            .stdout(contains("Excluded: 7"))
+            .stdout(contains("Successful: 0"))
+            .stdout(contains("Errors: 0"));
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,6 +6,7 @@ mod cli {
 
     #[test]
     fn test_exclude_all_private() {
+        // this gets the "main" binary name (e.g. `lychee`)
         let mut cmd =
             Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name");
 


### PR DESCRIPTION
Currently, the excludes are based purely on IP address ranges and only work for websites (no support for mail addresses). The IPv6 support is implemented, to a degree possible with Rust standard library as of 1.47.0. See commit messages and code comments for more details.

Note: while IP address exclude works, it's possible that some URLs will resolve to link-local, private or loopback addresses. While this is not very likely, it's a possibility. To address this, we'd have to DNS-resolve all URIs and then run them through IP exclude rules. I have skipped this part because of extra effort involved.

Closes #5.