### PR TITLE
Use action-rs Actions instead

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  build_and_test:
+    name: Rust project
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,3 @@
-name: Rust
-
 on:
   push:
     branches: [ master ]
@@ -11,7 +9,7 @@ env:
 
 jobs:
   build_and_test:
-    name: Rust project
+    name: Build and test with Cargo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,6 @@ env:
 
 jobs:
   build_and_test:
-    name: Build and test with Cargo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I don't know why but having most up-to-date Rust toolchain addressed #6.
This PR makes it so that we use `actions-rs/toolchain@v1` which always installs the latest stable versions.
The code is mostly copied from https://github.com/marketplace/actions/rust-cargo.