### PR TITLE
Actions improvements: add rustfmt and clippy checks, run tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions-rs/cargo@v1
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
         with:
           command: test
   lints:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_and_test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,8 +17,7 @@ jobs:
           toolchain: stable
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --release --all-features
+          command: test
   lints:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,3 +19,21 @@ jobs:
         with:
           command: build
           args: --release --all-features
+  lints:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Run cargo fmt (check if all code is rustfmt-ed)
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - name: Run cargo clippy (deny warnings)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -41,10 +41,8 @@ impl Status {
             if accepted.contains(&statuscode) {
                 return Status::Ok(statuscode);
             }
-        } else {
-            if statuscode.is_success() {
-                return Status::Ok(statuscode);
-            }
+        } else if statuscode.is_success() {
+            return Status::Ok(statuscode);
         };
         if statuscode.is_redirection() {
             Status::Redirected
@@ -83,6 +81,9 @@ pub(crate) struct Checker<'a> {
 
 impl<'a> Checker<'a> {
     /// Creates a new link checker
+    // we should consider adding a config struct for this, so that the list
+    // of arguments is short
+    #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         token: String,
         excludes: Option<RegexSet>,
@@ -179,7 +180,7 @@ impl<'a> Checker<'a> {
         status
     }
 
-    pub async fn valid_mail(&self, address: &String) -> bool {
+    pub async fn valid_mail(&self, address: &str) -> bool {
         let input = CheckEmailInput::new(vec![address.to_string()]);
         let results = check_email(&input).await;
         let result = results.get(0);
@@ -271,10 +272,8 @@ impl<'a> Checker<'a> {
             if let Some(message) = self.status_message(&ret, uri) {
                 pb.println(message);
             }
-        } else {
-            if let Some(message) = self.status_message(&ret, uri) {
-                println!("{}", message);
-            }
+        } else if let Some(message) = self.status_message(&ret, uri) {
+            println!("{}", message);
         }
 
         ret

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use checker::{Checker, Status};
 use extract::Uri;
 use options::LycheeOptions;
 
-fn print_summary(found: &HashSet<Uri>, results: &Vec<Status>) {
+fn print_summary(found: &HashSet<Uri>, results: &[Status]) {
     let found = found.len();
     let excluded: usize = results
         .iter()
@@ -31,7 +31,7 @@ fn print_summary(found: &HashSet<Uri>, results: &Vec<Status>) {
         .count();
     let errors: usize = found - excluded - success;
 
-    println!("");
+    println!();
     println!("📝Summary");
     println!("-------------------");
     println!("🔍Found: {}", found);


### PR DESCRIPTION
Following up on changes in #9, I have noticed that the new action definition only performs a `build`, without running the tests.

This PR introduces the following changes:
- The tests are ran as part of the `test` actions workflow, no longer merely building the code.
- The new `lints` actions workflow adds checks for:
  - `cargo fmt` (checks if all code is formatted using `rustfmt`)
  - `cargo clippy` (checks if there's any warnings produced by [clippy](https://github.com/rust-lang/rust-clippy)). In the process of adding this, I have addressed all the clippy warnings. There's one warning which I silenced, see: https://github.com/hello-rust/lychee/pull/10/files#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR86 -- That I think should be tackled in a separate PR.