### PR TITLE
Make GITHUB_TOKEN optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 ## What?
 
 This thing was created from [Hello Rust Episode
-10](https://hello-rust.show/10/). It's a link checker that treats Github links
-specially by using a `GITHUB_TOKEN` to avoid getting blocked by the rate
+10](https://hello-rust.show/10/). It's a link checker.
+
+For GitHub links, it can optionally use a `GITHUB_TOKEN` to avoid getting blocked by the rate
 limiter.
 
 ![Lychee demo](./assets/lychee.gif)
@@ -78,13 +79,20 @@ This comparison is made on a best-effort basis. Please create a PR to fix outdat
 cargo install lychee
 ```
 
-Set an environment variable with your token like so `GITHUB_TOKEN=xxxx`.
+Optional (to avoid being rate limited for GitHub links): set an environment variable with your token
+like so `GITHUB_TOKEN=xxxx`, or use the `--github-token` CLI option. This can also be set in the
+config file.
 
 Run it inside a repository with a `README.md` or specify a file with
 
 ```
 lychee <yourfile>
 ```
+
+### CLI return codes
+
+- `0` for success (all links checked successfully or excluded/skipped as configured)
+- `1` for any failures
 
 ## Comparison
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ Run it inside a repository with a `README.md` or specify a file with
 lychee <yourfile>
 ```
 
-### CLI return codes
+### CLI exit codes
 
 - `0` for success (all links checked successfully or excluded/skipped as configured)
-- `1` for any failures
+- `1` for any unexpected runtime failures or config errors
+- `2` for link check failures (if any non-excluded link failed the check)
 
 ## Comparison
 

--- a/fixtures/TEST_404.md
+++ b/fixtures/TEST_404.md
@@ -1,0 +1,3 @@
+Test file: this link should be a valid link but return a HTTP 404 when followed.
+
+http://httpbin.org/status/404

--- a/fixtures/TEST_GITHUB.md
+++ b/fixtures/TEST_GITHUB.md
@@ -1,0 +1,3 @@
+Test file: contains a single GitHub URL.
+
+Lychee: https://github.com/hello-rust/lychee

--- a/fixtures/TEST_GITHUB_404.md
+++ b/fixtures/TEST_GITHUB_404.md
@@ -1,0 +1,3 @@
+Test file: contains a single **invalid** (e.g. 404) GitHub URL.
+
+Lychee: https://github.com/mre/idiomatic-rust-doesnt-exist-man

--- a/fixtures/TEST_GITHUB_TOKEN.md
+++ b/fixtures/TEST_GITHUB_TOKEN.md
@@ -1,3 +1,0 @@
-Test file: test a GitHub URL, and check for GitHub token warnings.
-
-Lychee: https://github.com/hello-rust/lychee

--- a/fixtures/TEST_GITHUB_TOKEN.md
+++ b/fixtures/TEST_GITHUB_TOKEN.md
@@ -1,0 +1,3 @@
+Test file: test a GitHub URL, and check for GitHub token warnings.
+
+Lychee: https://github.com/hello-rust/lychee

--- a/src/options.rs
+++ b/src/options.rs
@@ -144,7 +144,6 @@ pub(crate) struct Config {
     pub basic_auth: Option<String>,
 
     #[structopt(
-        short,
         long,
         help = "GitHub API token to use when checking github.com links, to avoid rate limiting",
         env = "GITHUB_TOKEN"

--- a/src/options.rs
+++ b/src/options.rs
@@ -142,6 +142,15 @@ pub(crate) struct Config {
     #[structopt(long, help = "Basic autentication support. Ex 'username:password'")]
     #[serde(default)]
     pub basic_auth: Option<String>,
+
+    #[structopt(
+        short,
+        long,
+        help = "GitHub API token to use when checking github.com links, to avoid rate limiting",
+        env = "GITHUB_TOKEN"
+    )]
+    #[serde(default)]
+    pub github_token: Option<String>,
 }
 
 impl Config {
@@ -193,6 +202,7 @@ impl Config {
             method: METHOD;
             base_url: None;
             basic_auth: None;
+            github_token: None;
         }
 
         self

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,8 +17,7 @@ mod cli {
             .join("TEST_ALL_PRIVATE.md");
 
         // assert that the command runs OK, and that it excluded all the links
-        cmd.env("GITHUB_TOKEN", "invalid-token")
-            .arg("--exclude-all-private")
+        cmd.arg("--exclude-all-private")
             .arg("--verbose")
             .arg(test_all_private_path)
             .assert()
@@ -26,6 +25,30 @@ mod cli {
             .stdout(contains("Found: 7"))
             .stdout(contains("Excluded: 7"))
             .stdout(contains("Successful: 0"))
+            .stdout(contains("Errors: 0"));
+    }
+
+    #[test]
+    fn test_warn_github() {
+        let mut cmd =
+            Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name");
+
+        let test_github_token_path = Path::new(module_path!())
+            .parent()
+            .unwrap()
+            .join("fixtures")
+            .join("TEST_GITHUB_TOKEN.md");
+
+        // assert that the command runs OK, and that it excluded all the links
+        cmd.arg("--verbose")
+            .arg(test_github_token_path)
+            .assert()
+            .success()
+            .stdout(contains("[WARN] GitHub API token (`--github-token` / `GITHUB_TOKEN`) not specified. \
+                              This can lead to errors with GitHub links due to rate-limiting on github.com"))
+            .stdout(contains("Found: 1"))
+            .stdout(contains("Excluded: 0"))
+            .stdout(contains("Successful: 1"))
             .stdout(contains("Errors: 0"));
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -28,27 +28,72 @@ mod cli {
             .stdout(contains("Errors: 0"));
     }
 
+    /// Test that a GitHub link can be checked without specifying the token.
     #[test]
-    fn test_warn_github() {
+    fn test_check_github_no_token() {
         let mut cmd =
             Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name");
 
-        let test_github_token_path = Path::new(module_path!())
+        let test_github_path = Path::new(module_path!())
             .parent()
             .unwrap()
             .join("fixtures")
-            .join("TEST_GITHUB_TOKEN.md");
+            .join("TEST_GITHUB.md");
 
-        // assert that the command runs OK, and that it excluded all the links
         cmd.arg("--verbose")
-            .arg(test_github_token_path)
+            .arg(test_github_path)
             .assert()
             .success()
-            .stdout(contains("[WARN] GitHub API token (`--github-token` / `GITHUB_TOKEN`) not specified. \
-                              This can lead to errors with GitHub links due to rate-limiting on github.com"))
             .stdout(contains("Found: 1"))
             .stdout(contains("Excluded: 0"))
             .stdout(contains("Successful: 1"))
             .stdout(contains("Errors: 0"));
+    }
+
+    #[test]
+    fn test_failure_invalid_method() {
+        let mut cmd =
+            Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name");
+
+        cmd.arg("--method=invalid-method")
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(contains(
+                "Error: Only `get` and `head` allowed, got invalid-method",
+            ));
+    }
+
+    #[test]
+    fn test_failure_404_link() {
+        let mut cmd =
+            Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name");
+
+        let test_404_path = Path::new(module_path!())
+            .parent()
+            .unwrap()
+            .join("fixtures")
+            .join("TEST_404.md");
+
+        cmd.arg(test_404_path).assert().failure().code(2);
+    }
+
+    #[test]
+    fn test_failure_github_404_no_token() {
+        let mut cmd =
+            Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name");
+
+        let test_github_404_path = Path::new(module_path!())
+            .parent()
+            .unwrap()
+            .join("fixtures")
+            .join("TEST_GITHUB_404.md");
+
+        cmd.arg(test_github_404_path)
+            .assert()
+            .failure()
+            .code(2)
+            .stdout(contains("https://github.com/mre/idiomatic-rust-doesnt-exist-man \
+            (GitHub token not specified. To check GitHub links reliably, use `--github-token` flag / `GITHUB_TOKEN` env var.)"));
     }
 }


### PR DESCRIPTION
This also makes the token possible to pass in from CLI args.

I got bitten by this a few times, and decided that issuing a warning instead of failing would be a better choice in terms of user experience.

Happy to tweak the behavior to if you think the new default is not an improvement over the old one.